### PR TITLE
Point dams dependencies to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "dams"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/key-mgmt.git?branch=develop#f6e72bf66f9b6302334977ee2d3e7896d6e8a845"
+source = "git+https://github.com/boltlabs-inc/key-mgmt.git?branch=main#d3c80597dd56f06b501bd89ff2b280c4c20e0097"
 dependencies = [
  "argon2",
  "async-trait",
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "dams-client"
 version = "0.1.0"
-source = "git+https://github.com/boltlabs-inc/key-mgmt.git?branch=develop#f6e72bf66f9b6302334977ee2d3e7896d6e8a845"
+source = "git+https://github.com/boltlabs-inc/key-mgmt.git?branch=main#d3c80597dd56f06b501bd89ff2b280c4c20e0097"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-dams-client = { git = "https://github.com/boltlabs-inc/key-mgmt.git", branch = "develop", features=["allow_explicit_certificate_trust"]}
-dams = { git = "https://github.com/boltlabs-inc/key-mgmt.git", branch = "develop" }
+dams-client = { git = "https://github.com/boltlabs-inc/key-mgmt.git", branch = "main", features=["allow_explicit_certificate_trust"]}
+dams = { git = "https://github.com/boltlabs-inc/key-mgmt.git", branch = "main" }
 futures = "0"
 rand = "0"
 structopt = "0"

--- a/build-key-server.sh
+++ b/build-key-server.sh
@@ -3,6 +3,7 @@
 echo "[+] Clone and build key-mgmt repo..."
 git clone https://github.com/boltlabs-inc/key-mgmt.git
 cd key-mgmt
+git checkout main
 cargo build
 
 echo "[+] Generate a self-signed TLS certificate for key server..."


### PR DESCRIPTION
This PR point the dams dependencies and the cloned key server branch to `main` instead of `develop`.